### PR TITLE
Fixed Checking Player's Group Status.

### DIFF
--- a/lua/autorun/server/groupr.lua
+++ b/lua/autorun/server/groupr.lua
@@ -81,9 +81,9 @@ function GroupR.CheckGroup()
 	http.Fetch("http://steamcommunity.com/gid/"..GroupR.Config.GroupID.."/memberslistxml/?xml=1", function(body)
 		GroupR.GroupData = XMLToTable(body)
 		GroupR.Members = GroupR.GroupData.memberList.members.steamID64
-		for k,v in ipairs(player.GetAll()) do
-			if GroupR.Members[v:SteamID64()] then
-				GroupR.ProcessReward(v)
+		for i, p in ipairs(player.GetAll()) do
+			for k, v in pairs(GroupR.Members) do
+				if p:SteamID64() == v then GroupR.ProcessReward(p) end
 			end
 		end
 	end)


### PR DESCRIPTION
The addon would not index the tables correctly to check if the player was in the group.
This is how the table is layed out:

members:{
  steamID64:{
    1 = 16ui5019286091286,
    2 = ect...
  }
}

The addon tried to compare the SteamID64 to the index.